### PR TITLE
Silex 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: php
+
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+
+matrix:
+  allow_failures:
+    - php: hhvm
+
+before_script:
+  - composer self-update
+  - composer install --prefer-dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: php
 
 php:
@@ -6,10 +7,21 @@ php:
   - 7.0
   - hhvm
 
+env:
+  - MONGO_VERSION=1.5.8
+  - MONGO_VERSION=stable
+  - MONGO_VERSION=stable PREFER_LOWEST="--prefer-lowest"
+
 matrix:
   allow_failures:
     - php: hhvm
 
+services: mongodb
+
 before_script:
+  - if [ "x${MONGO_VERSION}" != "x" ]; then yes '' | pecl -q install -f mongo-${MONGO_VERSION}; fi
+  - if [ "x${MONGO_VERSION}" != "x" ]; then php --ri mongo; fi
   - composer self-update
-  - composer install --prefer-dist
+  - if [ "x${MONGODB_VERSION}" != "x" ]; then pecl install -f mongodb-${MONGODB_VERSION}; fi
+  - if [ "x${ADAPTER_VERSION}" != "x" ]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
+  - composer update --dev --no-interaction --prefer-source $PREFER_LOWEST

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^5.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     "license": "BSD-3-Clause",
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.4",
-        "silex/silex": "~1.3",
+        "php": ">=5.5",
+        "pimple/pimple": "^3.0",
         "mongodb/mongodb": "^1.0.0@beta"
     },
     "autoload": {
@@ -34,6 +34,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.1"
+        "phpunit/phpunit": "^4.8"
     }
 }

--- a/src/Coderockr/Mongodb/ServiceProvider.php
+++ b/src/Coderockr/Mongodb/ServiceProvider.php
@@ -2,13 +2,13 @@
 
 namespace Coderockr\Mongodb;
 
-use Silex\Application;
-use Silex\ServiceProviderInterface;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 use MongoDB\Driver\Manager;
 
 class ServiceProvider implements ServiceProviderInterface
 {
-    public function register(Application $app)
+    public function register(Container $app)
     {
         $app['mongodbs.options.initializer'] = $app->protect(function () use ($app) {
             static $initialized = false;
@@ -37,18 +37,18 @@ class ServiceProvider implements ServiceProviderInterface
             $app['mongodbs.options'] = $tmp;
         });
 
-        $app['mongodbs'] = $app->share(function (Application $app) {
+        $app['mongodbs'] = function () use ($app) {
             $app['mongodbs.options.initializer']();
 
-            $container = new \Pimple();
+            $container = new Container();
             foreach ($app['mongodbs.options'] as $name => $options) {
-                $container[$name] = $container->share(function () use ($options) {
+                $container[$name] = function () use ($options) {
                     return new Manager($options['uri'], $options['options'], $options['driverOptions']);
-                });
+                };
             }
 
             return $container;
-        });
+        };
 
         $app['mongodb.default_options'] = [
             'uri' => 'mongodb://localhost:27017',
@@ -57,12 +57,9 @@ class ServiceProvider implements ServiceProviderInterface
         ];
 
         // shortcuts for the "first" MongoDB
-        $app['mongodb'] = $app->share(function (Application $app) {
+        $app['mongodb'] = function () use ($app) {
             $dbs = $app['mongodbs'];
             return $dbs[$app['mongodbs.default']];
-        });
+        };
     }
-
-    public function boot(Application $app)
-    {}
 }

--- a/tests/Coderockr/Mongodb/ServiceProviderTest.php
+++ b/tests/Coderockr/Mongodb/ServiceProviderTest.php
@@ -1,12 +1,11 @@
 <?php
 namespace Coderockr\Mongodb\Test;
 
-use Silex\Application;
-use Silex\WebTestCase;
+use Pimple\Container;
 use Coderockr\Mongodb\ServiceProvider as MongodbServiceProvider;
 use MongoDB\Driver\Manager;
 
-class ServiceProviderTest extends WebTestCase
+class ServiceProviderTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @test
@@ -52,9 +51,6 @@ class ServiceProviderTest extends WebTestCase
 
     public function createApplication()
     {
-        $app = new Application();
-        $app['debug'] = true;
-        $app['exception_handler']->disable();
-        return $app;
+        return new Container();
     }
 }


### PR DESCRIPTION
Foi removido o Silex 2 das dependências, para permitir utilizar o provider também em outros ambientes sem toda stack do silex.

Como o Silex extends o `Pimple\Container`, é compatível.

O downgrade do phpunit foi feito por causa da versão do php, mas é discutível. 
